### PR TITLE
Fix typo in get_video_duration function name

### DIFF
--- a/src-tauri/src/lib/tauri_commands/ffmpeg.rs
+++ b/src-tauri/src/lib/tauri_commands/ffmpeg.rs
@@ -40,7 +40,7 @@ pub async fn generate_video_thumbnail(
 }
 
 #[tauri::command]
-pub async fn get_vide_duration(
+pub async fn get_video_duration(
     app: tauri::AppHandle,
     video_path: &str,
 ) -> Result<Option<String>, String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,8 +8,8 @@ use tauri_plugin_log::{Target as LogTarget, TargetKind as LogTargetKind};
 use lib::tauri_commands::{
     command::{__cmd__show_item_in_file_manager, show_item_in_file_manager},
     ffmpeg::{
-        __cmd__compress_video, __cmd__generate_video_thumbnail, __cmd__get_vide_duration,
-        compress_video, generate_video_thumbnail, get_vide_duration,
+        __cmd__compress_video, __cmd__generate_video_thumbnail, __cmd__get_video_duration,
+        compress_video, generate_video_thumbnail, get_video_duration,
     },
     fs::{
         __cmd__delete_cache, __cmd__delete_file, __cmd__get_file_metadata,
@@ -53,7 +53,7 @@ async fn main() {
         .invoke_handler(tauri::generate_handler![
             compress_video,
             generate_video_thumbnail,
-            get_vide_duration,
+            get_video_duration,
             get_image_dimension,
             get_file_metadata,
             move_file,

--- a/src/tauri/commands/ffmpeg.ts
+++ b/src/tauri/commands/ffmpeg.ts
@@ -32,5 +32,5 @@ export function getFileMetadata(filePath: string): Promise<FileMetadata> {
 }
 
 export function getVideoDuration(videoPath: string): Promise<string | null> {
-  return core.invoke('get_vide_duration', { videoPath })
+  return core.invoke('get_video_duration', { videoPath })
 }


### PR DESCRIPTION
Hey there! super handy app, thanks for your work on this - it's really interesting to see a cross-platform app that uses native libraries + rust + next. What agreat idea

If you'll accept a tiny PR, I came across this typo while looking at compress0's code:

This pull request fixes a typo in the `get_video_duration` function, where it was mistakenly named `get_vide_duration`. This typo has been corrected to ensure the function is properly named and matches other ffmpeg calls in the app