### PR TITLE
Make drag and drop case insensitive

### DIFF
--- a/src/app/(root)/ui/DragAndDrop.tsx
+++ b/src/app/(root)/ui/DragAndDrop.tsx
@@ -59,7 +59,7 @@ function DragAndDrop({ disable = false, onFile }: DragAndDropProps) {
               const filePathSplitted = filePath?.split('.')
               if (filePathSplitted.length) {
                 const fileExtension =
-                  filePathSplitted?.[filePathSplitted.length - 1]
+                  filePathSplitted?.[filePathSplitted.length - 1].toLowerCase()
                 if (!videoExtensions?.includes(fileExtension)) {
                   toast.error('Invalid video file.')
                 } else {


### PR DESCRIPTION
Just uses .toLowerCase() to make the drag and drop handler case insensitive, so it doesn't reject mp4 files when they're named `.MP4`.