### PR TITLE
fix: use hvc1 codec tag for HEVC output on macOS

### DIFF
--- a/src-tauri/src/core/ffmpeg.rs
+++ b/src-tauri/src/core/ffmpeg.rs
@@ -260,6 +260,15 @@ impl FFMPEG {
         };
         cmd_args.extend_from_slice(&["-c:v:0", output_codec.as_str()]);
 
+        // For HEVC codecs in MP4/MOV containers, use hvc1 tag for Apple compatibility.
+        // By default ffmpeg writes hev1, which macOS Finder/QuickLook/QuickTime don't recognize.
+        let needs_hvc1_tag = (output_codec.contains("265")
+            || output_codec.contains("hevc"))
+            && matches!(convert_to_extension, "mp4" | "mov");
+        if needs_hvc1_tag {
+            cmd_args.extend_from_slice(&["-tag:v:0", "hvc1"]);
+        }
+
         // Quality
         let compression_quality: String = {
             let default_crf: u16 = 28;


### PR DESCRIPTION
## Summary
- Fixes HEVC-compressed videos having no thumbnails in macOS Finder and failing QuickLook preview
- ffmpeg defaults to `hev1` codec tag for HEVC, but Apple's AVFoundation only recognizes `hvc1`
- Appends `-tag:v:0 hvc1` when output codec is HEVC and container is MP4/MOV

## Changes
- Added 8 lines in `src-tauri/src/core/ffmpeg.rs` after the video codec is set
- Detects HEVC codec (checks for "265" or "hevc" in codec string)
- Only applies to MP4/MOV containers where the tag matters
- Zero-cost metadata-only change — no impact on quality, file size, or encoding speed
- Non-Apple players accept both `hev1` and `hvc1` equally

## Test plan
- [x] `cargo check` passes
- [ ] Compress a video with HEVC codec to MP4 on macOS
- [ ] Verify thumbnail appears in Finder
- [ ] Verify QuickLook (spacebar) works
- [ ] Verify playback in VLC/mpv still works

Fixes #122